### PR TITLE
feat: add purchase order detail view

### DIFF
--- a/src/app/compras/ComprasClient.tsx
+++ b/src/app/compras/ComprasClient.tsx
@@ -7,6 +7,7 @@ import ComprasFilters from "@/components/compras/ComprasFilters";
 import ComprasTable from "@/components/compras/ComprasTable";
 import ComprasStatsCards from "@/components/compras/ComprasStatsCards";
 import ComprasModal from "@/components/compras/ComprasModal";
+import ComprasDetailDialog from "@/components/compras/ComprasDetailDialog";
 
 import { Button } from "@/components/ui/Button";
 import { Plus } from 'lucide-react';
@@ -38,6 +39,8 @@ export default function ComprasClient({ initialOrders, proveedores, depositos, p
   const [orders, setOrders] = useState<PurchaseOrder[]>(initialOrders);
   const [filters, setFilters] = useState<ComprasFiltersState>({});
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [selectedOrder, setSelectedOrder] = useState<PurchaseOrder | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
 
   // Hooks propios
   const { sort, setSort, toggle } = useComprasSort({ key: "creationDate", dir: "desc" });
@@ -65,8 +68,10 @@ export default function ComprasClient({ initialOrders, proveedores, depositos, p
 
   // Navegación “Ver”
   function onView(id: string) {
-    // TODO: reemplazar por router.push(`/compras/${id}`)
-    alert(`Ver detalle de ${id} (pendiente de /compras/[id])`);
+    const order = orders.find((o) => o.id === id);
+    if (!order) return;
+    setSelectedOrder(order);
+    setDetailOpen(true);
   }
 
   // Editar
@@ -79,7 +84,8 @@ export default function ComprasClient({ initialOrders, proveedores, depositos, p
   // Crear / Actualizar (server actions)
   async function handleSubmit(payload: {
     proveedorId: string;
-    deposito: string;
+    depositoId: string;
+    depositoNombre?: string;
     fechaEntrega: string; // yyyy-mm-dd
     items: PurchaseOrderItem[];
     totalCantidad: number;
@@ -88,6 +94,13 @@ export default function ComprasClient({ initialOrders, proveedores, depositos, p
     setOpen(false);
     setEditingId(null);
     // TODO: disparar ToastNotificacion si querés
+  }
+
+  function handleDetailOpenChange(open: boolean) {
+    setDetailOpen(open);
+    if (!open) {
+      setSelectedOrder(null);
+    }
   }
 
   function onOpenNew() {
@@ -166,7 +179,7 @@ export default function ComprasClient({ initialOrders, proveedores, depositos, p
                 const o = orders.find((x) => x.id === editingId)!;
                 return {
                   proveedorId: o.supplier.id,
-                  deposito: o.warehouse,
+                  depositoId: o.warehouseId ?? "",
                   fechaEntrega: toYYYYMMDD(o.deliveryDate),
                   items: o.items,
                 };
@@ -175,14 +188,23 @@ export default function ComprasClient({ initialOrders, proveedores, depositos, p
         }
         onSubmit={handleSubmit}
       />
-  </main>  
+
+      <ComprasDetailDialog
+        order={selectedOrder}
+        open={detailOpen}
+        onOpenChange={handleDetailOpenChange}
+      />
+  </main>
 );
 }
 
 /* ========= Helpers locales ========= */
 function pad(n: number) { return n.toString().padStart(2, "0"); }
 
-function toYYYYMMDD(dd_mm_yyyy: string) {
-  const [d, m, y] = dd_mm_yyyy.split("/").map(Number);
+function toYYYYMMDD(date: string) {
+  if (!date) return "";
+  if (date.includes("-")) return date;
+  const [d, m, y] = date.split("/").map(Number);
+  if (!d || !m || !y) return "";
   return `${y}-${pad(m)}-${pad(d)}`;
 }

--- a/src/components/compras/ComprasDetailDialog.tsx
+++ b/src/components/compras/ComprasDetailDialog.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import Badge from "@/components/ui/Badge";
+import Button from "@/components/ui/Button";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogFooter,
+} from "@/components/ui/alert-dialog";
+import type { PurchaseOrder } from "@/lib/compras/purchase";
+
+type Props = {
+  order: PurchaseOrder | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function ComprasDetailDialog({ order, open, onOpenChange }: Props) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="glass-effect p-0 w-full max-w-4xl overflow-hidden">
+        <div className="bg-gradient-to-r from-primary-pink to-light-pink px-6 py-5 flex items-start justify-between">
+          <AlertDialogHeader className="space-y-1">
+            <AlertDialogTitle className="text-2xl font-bold text-white">
+              Detalle de la Orden de Compra
+            </AlertDialogTitle>
+            <p className="text-white/80">
+              {order ? `OC #${order.id}` : "Selecciona una orden para ver sus detalles"}
+            </p>
+          </AlertDialogHeader>
+
+          {order && (
+            <Badge
+              className={`text-white ${
+                order.status === "Completa" ? "status-active" : "status-inactive"
+              }`}
+            >
+              {order.status}
+            </Badge>
+          )}
+        </div>
+
+        <div className="px-6 py-6 space-y-8 max-h-[70vh] overflow-y-auto bg-white/95">
+          {order ? (
+            <>
+              <section className="space-y-4">
+                <h3 className="text-lg font-semibold text-blue-900">Información general</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <DetailItem label="Fecha de creación" value={order.creationDate} />
+                  <DetailItem
+                    label="Hora de creación"
+                    value={order.creationTime ? `${order.creationTime} hs` : "—"}
+                  />
+                  <DetailItem
+                    label="Depósito"
+                    value={order.warehouse || "—"}
+                  />
+                  <DetailItem
+                    label="Fecha de entrega"
+                    value={order.deliveryDate || "—"}
+                  />
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <h3 className="text-lg font-semibold text-blue-900">Proveedor</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <DetailItem label="Nombre" value={order.supplier.name} />
+                  <DetailItem label="Código" value={order.supplier.code || "—"} />
+                </div>
+              </section>
+
+              <section className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-semibold text-blue-900">Productos</h3>
+                  <span className="text-sm text-gray-500">
+                    Cantidad total: {order.totalQuantity ?? 0}
+                  </span>
+                </div>
+
+                {order.items.length > 0 ? (
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full text-sm">
+                      <thead className="bg-gray-50 text-left text-gray-600">
+                        <tr>
+                          <th className="px-4 py-3 font-semibold">Producto</th>
+                          <th className="px-4 py-3 font-semibold">Cantidad</th>
+                          <th className="px-4 py-3 font-semibold">Precio unitario</th>
+                          <th className="px-4 py-3 font-semibold">Subtotal</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {order.items.map((item) => (
+                          <tr key={item.id}>
+                            <td className="px-4 py-3 text-gray-800">{item.productName}</td>
+                            <td className="px-4 py-3 text-gray-600">{item.quantity}</td>
+                            <td className="px-4 py-3 text-gray-600">
+                              ${formatMoney(item.unitPrice)}
+                            </td>
+                            <td className="px-4 py-3 font-semibold text-gray-900">
+                              ${formatMoney(item.totalPrice)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <div className="p-6 bg-gray-50 text-sm text-gray-500 rounded-xl border border-dashed border-gray-200">
+                    Esta orden todavía no tiene productos asociados.
+                  </div>
+                )}
+              </section>
+
+              <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <SummaryCard label="Total productos" value={`${order.items.length}`} />
+                <SummaryCard label="Cantidad total" value={`${order.totalQuantity ?? 0}`} />
+                <SummaryCard label="Monto total" value={`$${formatMoney(order.total)}`} />
+              </section>
+            </>
+          ) : (
+            <div className="text-center text-gray-500 py-12">
+              Selecciona una orden para ver sus detalles.
+            </div>
+          )}
+        </div>
+
+        <AlertDialogFooter className="px-6 py-4 bg-white/90">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cerrar
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+type DetailItemProps = {
+  label: string;
+  value: string | number;
+};
+
+function DetailItem({ label, value }: DetailItemProps) {
+  return (
+    <div className="p-4 bg-white rounded-xl border border-gray-200 shadow-sm">
+      <span className="text-xs uppercase tracking-wide text-gray-400">{label}</span>
+      <p className="mt-1 text-sm font-semibold text-gray-800">{value}</p>
+    </div>
+  );
+}
+
+type SummaryCardProps = {
+  label: string;
+  value: string;
+};
+
+function SummaryCard({ label, value }: SummaryCardProps) {
+  return (
+    <div className="p-4 bg-gradient-to-br from-gray-50 to-white border border-gray-200 rounded-xl shadow-sm">
+      <span className="text-xs uppercase tracking-wide text-gray-400">{label}</span>
+      <p className="mt-2 text-lg font-semibold text-blue-900">{value}</p>
+    </div>
+  );
+}
+
+function formatMoney(value: number | undefined) {
+  return (value ?? 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}

--- a/src/components/compras/ComprasModal.tsx
+++ b/src/components/compras/ComprasModal.tsx
@@ -1,7 +1,7 @@
 // src/components/compras/ComprasModal.tsx
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Button from "@/components/ui/Button";
 import Input from "@/components/ui/Input";
 import Select from "@/components/ui/Select";
@@ -9,8 +9,6 @@ import {
   AlertDialog,
   AlertDialogContent,
   AlertDialogTitle,
-  AlertDialogHeader,
-  AlertDialogFooter,
 } from "@/components/ui/alert-dialog";
 import type { Product, PurchaseOrderItem } from "@/lib/compras/purchase";
 
@@ -19,11 +17,12 @@ type Props = {
   onOpenChange: (v: boolean) => void;
 
   proveedores: { id: string; name: string }[];
-  depositos: string[];
+  depositos: { id: string; name: string }[];
   productos: Product[];
 
   initial?: {
     proveedorId?: string;
+    depositoId?: string;
     deposito?: string;
     fechaEntrega?: string; // yyyy-mm-dd
     items?: PurchaseOrderItem[];
@@ -31,7 +30,8 @@ type Props = {
 
   onSubmit: (payload: {
     proveedorId: string;
-    deposito: string;
+    depositoId: string;
+    depositoNombre?: string;
     fechaEntrega: string;
     items: PurchaseOrderItem[];
     totalCantidad: number;
@@ -53,7 +53,7 @@ export default function ComprasModal({
   onSubmit,
 }: Props) {
   const [proveedorId, setProveedorId] = useState(initial?.proveedorId ?? "");
-  const [deposito, setDeposito] = useState(initial?.deposito ?? "");
+  const [depositoId, setDepositoId] = useState(initial?.depositoId ?? initial?.deposito ?? "");
   const [fechaEntrega, setFechaEntrega] = useState(initial?.fechaEntrega ?? "");
   const [items, setItems] = useState<PurchaseOrderItem[]>(initial?.items ?? []);
 
@@ -88,179 +88,195 @@ export default function ComprasModal({
     setItems((arr) => arr.filter((x) => x.id !== id));
   }
 
+  useEffect(() => {
+    if (!open) return;
+    setProveedorId(initial?.proveedorId ?? "");
+    setDepositoId(initial?.depositoId ?? initial?.deposito ?? "");
+    setFechaEntrega(initial?.fechaEntrega ?? "");
+    setItems(initial?.items ?? []);
+  }, [open, initial]);
+
   function submit() {
-    if (!proveedorId || !deposito || !fechaEntrega || items.length === 0) return;
-    onSubmit({ proveedorId, deposito, fechaEntrega, items, totalCantidad, totalMonto });
+    if (!proveedorId || !depositoId || !fechaEntrega || items.length === 0) return;
+    const depositoNombre = depositos.find((d) => d.id === depositoId)?.name;
+    onSubmit({
+      proveedorId,
+      depositoId,
+      depositoNombre,
+      fechaEntrega,
+      items,
+      totalCantidad,
+      totalMonto,
+    });
   }
 
-return (
-  <AlertDialog open={open} onOpenChange={onOpenChange}>
-    <AlertDialogContent
-      className="
-        glass-effect
-        p-0 overflow-hidden
-        w-full max-w-3xl md:max-w-5xl
-        h-[75vh]
-      "
-    >
-      {/* Header (gradiente como el otro modal) */}
-      <div className="flex-none p-6 rounded-t-2xl bg-gradient-to-r from-primary-pink to-light-pink">
-        <div className="flex items-center justify-between">
-          <AlertDialogTitle className="text-2xl font-bold text-white">
-            Registrar Nueva Orden de Compra
-          </AlertDialogTitle>
-          <button
-            onClick={() => onOpenChange(false)}
-            className="text-white hover:bg-white/20 p-2 rounded-lg"
-            aria-label="Cerrar modal"
-          >
-            ✕
-          </button>
-        </div>
-      </div>
-
-      {/* Body scrolleable */}
-      <div className="flex-auto overflow-y-auto p-8 space-y-8">
-        {/* Cabecera */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <Select
-            label="Proveedor *"
-            value={proveedorId}
-            onChange={(e) => setProveedorId(e.target.value)}
-            className="input-focus"
-          >
-            <option value="">Seleccionar proveedor</option>
-            {proveedores.map((p) => (
-              <option key={p.id} value={p.id}>{p.name}</option>
-            ))}
-          </Select>
-
-          <Select
-            label="Depósito *"
-            value={deposito}
-            onChange={(e) => setDeposito(e.target.value)}
-            className="input-focus"
-          >
-            <option value="">Seleccionar depósito</option>
-            {depositos.map((d) => (
-              <option key={d} value={d}>{d}</option>
-            ))}
-          </Select>
-
-          <Input
-            label="Fecha de Entrega *"
-            type="date"
-            value={fechaEntrega}
-            onChange={(e) => setFechaEntrega(e.target.value)}
-            className="input-focus"
-          />
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent
+        className="
+          glass-effect
+          p-0 overflow-hidden
+          w-full max-w-3xl md:max-w-5xl
+          h-[75vh]
+        "
+      >
+        {/* Header (gradiente como el otro modal) */}
+        <div className="flex-none p-6 rounded-t-2xl bg-gradient-to-r from-primary-pink to-light-pink">
+          <div className="flex items-center justify-between">
+            <AlertDialogTitle className="text-2xl font-bold text-white">
+              Registrar Nueva Orden de Compra
+            </AlertDialogTitle>
+            <button
+              onClick={() => onOpenChange(false)}
+              className="text-white hover:bg-white/20 p-2 rounded-lg"
+              aria-label="Cerrar modal"
+            >
+              ✕
+            </button>
+          </div>
         </div>
 
-        {/* Productos (caja igual estilo al otro) */}
-        <div>
-          <h4 className="text-md font-semibold text-gray-800 mb-4">Productos *</h4>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 p-4 bg-gray-50 rounded-xl border border-gray-200">
+        {/* Body scrolleable */}
+        <div className="flex-auto overflow-y-auto p-8 space-y-8">
+          {/* Cabecera */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <Select
-              label="Producto"
-              value={prodSel}
-              onChange={(e) => setProdSel(e.target.value)}
+              label="Proveedor *"
+              value={proveedorId}
+              onChange={(e) => setProveedorId(e.target.value)}
               className="input-focus"
             >
-              <option value="">Seleccionar…</option>
-              {productos.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name} - ${money(p.price ?? 0)}
-                </option>
+              <option value="">Seleccionar proveedor</option>
+              {proveedores.map((p) => (
+                <option key={p.id} value={p.id}>{p.name}</option>
+              ))}
+            </Select>
+
+            <Select
+              label="Depósito *"
+              value={depositoId}
+              onChange={(e) => setDepositoId(e.target.value)}
+              className="input-focus"
+            >
+              <option value="">Seleccionar depósito</option>
+              {depositos.map((d) => (
+                <option key={d.id} value={d.id}>{d.name}</option>
               ))}
             </Select>
 
             <Input
-              label="Cantidad"
-              type="number"
-              min={1}
-              value={qty}
-              onChange={(e) => setQty(Math.max(1, Number(e.target.value || 1)))}
+              label="Fecha de Entrega *"
+              type="date"
+              value={fechaEntrega}
+              onChange={(e) => setFechaEntrega(e.target.value)}
               className="input-focus"
             />
-
-            <Input
-              label="Precio Unitario"
-              type="number"
-              min={0}
-              step="1"
-              value={unit}
-              onChange={(e) => setUnit(Math.max(0, Number(e.target.value || 0)))}
-              //hint="Si lo dejás en 0, se toma el precio del producto"
-              className="input-focus"
-            />
-
-            <div className="flex items-end">
-              <Button className="w-full" onClick={addItem}>
-                Agregar producto
-              </Button>
-            </div>
           </div>
-        </div>
 
-        {/* Tabla de ítems + resumen (en “card” con borde/redondeado) */}
-        {items.length > 0 && (
-          <div className="rounded-xl border border-gray-200 overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Producto</th>
-                    <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Cantidad</th>
-                    <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Precio Unit.</th>
-                    <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Subtotal</th>
-                    <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Acciones</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {items.map((it, idx) => (
-                    <tr key={it.id} className={idx % 2 === 0 ? "bg-white" : "bg-gray-50"}>
-                      <td className="px-4 py-3 font-medium text-gray-900">{it.productName}</td>
-                      <td className="px-4 py-3 text-gray-700">{it.quantity}</td>
-                      <td className="px-4 py-3 text-gray-700">${money(it.unitPrice)}</td>
-                      <td className="px-4 py-3 font-semibold text-gray-900">${money(it.totalPrice)}</td>
-                      <td className="px-4 py-3">
-                        <Button size="sm" variant="ghost" onClick={() => removeItem(it.id)}>
-                          Eliminar
-                        </Button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+          {/* Productos (caja igual estilo al otro) */}
+          <div>
+            <h4 className="text-md font-semibold text-gray-800 mb-4">Productos *</h4>
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 p-4 bg-gray-50 rounded-xl border border-gray-200">
+              <Select
+                label="Producto"
+                value={prodSel}
+                onChange={(e) => setProdSel(e.target.value)}
+                className="input-focus"
+              >
+                <option value="">Seleccionar…</option>
+                {productos.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name} - ${money(p.price ?? 0)}
+                  </option>
+                ))}
+              </Select>
 
-            {/* Resumen */}
-            <div className="p-6 flex justify-end">
-              <div className="text-right">
-                <div className="text-sm text-gray-600 mb-1">Cantidad Total: {totalCantidad}</div>
-                <div className="text-2xl font-bold text-blue-800">Total: ${money(totalMonto)}</div>
+              <Input
+                label="Cantidad"
+                type="number"
+                min={1}
+                value={qty}
+                onChange={(e) => setQty(Math.max(1, Number(e.target.value || 1)))}
+                className="input-focus"
+              />
+
+              <Input
+                label="Precio Unitario"
+                type="number"
+                min={0}
+                step="1"
+                value={unit}
+                onChange={(e) => setUnit(Math.max(0, Number(e.target.value || 0)))}
+                //hint="Si lo dejás en 0, se toma el precio del producto"
+                className="input-focus"
+              />
+
+              <div className="flex items-end">
+                <Button className="w-full" onClick={addItem}>
+                  Agregar producto
+                </Button>
               </div>
             </div>
           </div>
-        )}
 
-        {/* Actions (al pie, como el otro diseño) */}
-        <div className="flex justify-end gap-4 pt-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancelar
-          </Button>
-          <Button
-            variant="primary"
-            className="btn-primary"
-            disabled={!proveedorId || !deposito || !fechaEntrega || items.length === 0}
-            onClick={submit}
-          >
-            Registrar Orden de Compra
-          </Button>
+          {/* Tabla de ítems + resumen (en “card” con borde/redondeado) */}
+          {items.length > 0 && (
+            <div className="rounded-xl border border-gray-200 overflow-hidden">
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Producto</th>
+                      <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Cantidad</th>
+                      <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Precio Unit.</th>
+                      <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Subtotal</th>
+                      <th className="px-4 py-3 text-left text-sm font-bold text-blue-800">Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {items.map((it, idx) => (
+                      <tr key={it.id} className={idx % 2 === 0 ? "bg-white" : "bg-gray-50"}>
+                        <td className="px-4 py-3 font-medium text-gray-900">{it.productName}</td>
+                        <td className="px-4 py-3 text-gray-700">{it.quantity}</td>
+                        <td className="px-4 py-3 text-gray-700">${money(it.unitPrice)}</td>
+                        <td className="px-4 py-3 font-semibold text-gray-900">${money(it.totalPrice)}</td>
+                        <td className="px-4 py-3">
+                          <Button size="sm" variant="ghost" onClick={() => removeItem(it.id)}>
+                            Eliminar
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Resumen */}
+              <div className="p-6 flex justify-end">
+                <div className="text-right">
+                  <div className="text-sm text-gray-600 mb-1">Cantidad Total: {totalCantidad}</div>
+                  <div className="text-2xl font-bold text-blue-800">Total: ${money(totalMonto)}</div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Actions (al pie, como el otro diseño) */}
+          <div className="flex justify-end gap-4 pt-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button
+              variant="primary"
+              className="btn-primary"
+              disabled={!proveedorId || !depositoId || !fechaEntrega || items.length === 0}
+              onClick={submit}
+            >
+              Registrar Orden de Compra
+            </Button>
+          </div>
         </div>
-      </div>
-    </AlertDialogContent>
-  </AlertDialog>
-);
-
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }

--- a/src/lib/compras/purchase.ts
+++ b/src/lib/compras/purchase.ts
@@ -46,7 +46,8 @@ export type ComprasFiltersState = {
   numeroOC?: string;
   proveedorId?: string;
   depositoId?: string;   // ← nuevo: filtrar por ID de depósito
-  deposito?: string;     // ← opcional/legacy (por nombre). Puedes quitarlo si ya no lo usas.};
+  deposito?: string;     // ← opcional/legacy (por nombre). Puedes quitarlo si ya no lo usas.
+};
 
 // Ordenamiento
 export type SortKey = "id" | "creationDate" | "supplier" | "warehouse" | "total" | "status";


### PR DESCRIPTION
## Summary
- add a dedicated dialog to review purchase order details from the main table
- normalize purchase order modal props to work with deposito ids and refresh initial values when editing
- improve date conversion helper to handle missing values gracefully

## Testing
- npm run lint *(fails: existing eslint errors in generated prisma runtime and server layers)*

------
https://chatgpt.com/codex/tasks/task_e_68cda6baac748330b485f80016043b4a