### PR TITLE
Load products in compras page

### DIFF
--- a/src/app/compras/page.tsx
+++ b/src/app/compras/page.tsx
@@ -1,7 +1,7 @@
 // src/app/compras/page.tsx
 import ComprasClient from "./ComprasClient";
 //import { productsMock, suppliersMock, depositosMocks} from "@/mocks/compras.mock"
-import { getPurchaseOrders } from "@/server/compras/compras.service";
+import { getPurchaseOrders, getProducts } from "@/server/compras/compras.service";
 import { getSuppliersService } from "@/server/proveedores/proveedores.service";
 import { getDepositosService } from "@/server/deposito/depositos.service"; // devuelve objetos
 
@@ -10,10 +10,11 @@ import { getDepositosService } from "@/server/deposito/depositos.service"; // de
 // Si más adelante querés consumir una API real, podés hacer fetch desde aquí (server component)
 export default async function Page() {
   //const initialOrders = await getPurchaseOrders({ limit: 100, sort: "desc" });
-  const [initialOrders, proveedores, depositosRows] = await Promise.all([
+  const [initialOrders, proveedores, depositosRows, productosRows] = await Promise.all([
     getPurchaseOrders({ limit: 100, sort: "desc" }),
     getSuppliersService({ status: "active", limit: 100 }), // ajustá según tu listarProveedores
     getDepositosService({ /*estado: "Activo"*/ }),
+    getProducts(),
   ]);
 
   // Mock directo (en real: await fetch + cache/revalidate)
@@ -24,7 +25,14 @@ export default async function Page() {
   //const depositos = depositosRows.map(d => d.name); // ["Depósito Central", "Depósito Norte", ...]
   //const depositosRows = await getDepositosService({ /* estado: "Activo" */ });
   const depositos = depositosRows.map(d => ({ id: d.id, name: d.name }));
-  const productos: any[] = []; // cuando tengas endpoint de productos, hacemos el mismo patrón
+  const productos = productosRows
+    .filter((p) => p?.id && p?.name)
+    .map((p) => ({
+      id: p.id,
+      name: p.name,
+      price: Number(p.price ?? 0),
+      code: p.code ?? "",
+    }));
 
   return (
     <div className="p-2">


### PR DESCRIPTION
## Summary
- fetch products alongside purchase orders, suppliers, and depósitos in the compras page
- pass the fetched products to the ComprasClient with id, name, and price information so the modal select lists options correctly

## Testing
- npm run lint *(fails: pre-existing lint errors in generated Prisma files and server services)*

------
https://chatgpt.com/codex/tasks/task_e_68cdac352d688330ac662d0182199bc6