### PR TITLE
feat: integrar comprobantes de proveedor con APIs

### DIFF
--- a/src/app/comprobante-proveedor/actions/comprobante.ts
+++ b/src/app/comprobante-proveedor/actions/comprobante.ts
@@ -1,21 +1,185 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import type { ComprobanteProveedor, DetalleComprobanteProveedor } from "@/lib/comprobante-proveedor/comprobante";
+import type {
+  ComprobanteProveedor,
+  DetalleComprobanteProveedor,
+  Supplier,
+  Deposito,
+  TipoMovimiento,
+  PurchaseOrder,
+} from "@/lib/comprobante-proveedor/comprobante";
+import type { ComprobanteListItem, ComprobanteListResponse } from "@/lib/comprobante-proveedor/types";
 
-// Base URL de tu API (asegurate de definir NEXT_PUBLIC_BASE_URL en .env)
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL!;
+const FALLBACK_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
+  ?? process.env.NEXT_BASE_URL
+  ?? "http://localhost:3000";
+
+function buildUrl(path: string): string {
+  try {
+    return new URL(path, FALLBACK_BASE_URL).toString();
+  } catch (err) {
+    console.error("[comprobante actions] URL inválida", path, err);
+    throw err;
+  }
+}
+
+async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const url = path.startsWith("http") ? path : buildUrl(path);
+  const res = await fetch(url, { cache: "no-store", ...init });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Fetch ${url} failed (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+function mapListItemToComprobante(item: ComprobanteListItem): ComprobanteProveedor {
+  const numeroFmt = item.nro_comprobante ?? `CP-${item.id}`;
+  const proveedor: Supplier = {
+    id: String(item.proveedor?.id ?? ""),
+    name: item.proveedor?.name ?? "Proveedor",
+  };
+
+  const deposito: Deposito = item.deposito
+    ? { id: String(item.deposito.id), name: item.deposito.name }
+    : { id: "", name: "Sin depósito" };
+
+  const ordenCompra: PurchaseOrder = {
+    id: item.ordenCompra ? String(item.ordenCompra.id) : "-",
+    supplier: proveedor,
+    deposito,
+    status: Boolean(item.estado),
+    items: [],
+  };
+
+  const tipoMovimiento: TipoMovimiento = {
+    id: item.pendiente > 0 ? "pendiente" : "cancelado",
+    name: item.pendiente > 0 ? "Pendiente" : "Cancelado",
+    saldo: item.pendiente > 0,
+  };
+
+  return {
+    id: numeroFmt,
+    ordenCompra,
+    proveedor,
+    deposito,
+    letra: null,
+    numeroSucursal: null,
+    numero: numeroFmt,
+    moneda: null,
+    tipoComprobante: {
+      id: item.tipo_comprobante ? String(item.tipo_comprobante) : "",
+      name: item.tipo_comprobante ?? "Sin tipo",
+    },
+    fecha: item.fecha ?? "",
+    hora: null,
+    total: item.total ?? 0,
+    saldo: item.saldo ?? item.pendiente ?? 0,
+    metodoPagoId: undefined,
+    estado: Boolean(item.estado),
+    observaciones: null,
+    tipoMovimiento,
+    items: [],
+  };
+}
 
 // ===== Listar comprobantes con relaciones =====
 export async function listComprobanteAction(): Promise<ComprobanteProveedor[]> {
-  const res = await fetch(`${baseUrl}/api/comprobantes-proveedor?include=proveedor,deposito,ordenCompra,tipoComprobante,metodoPago,tipoMovimiento,items`, {
-    cache: "no-store",
-  });
+  const data = await fetchJson<ComprobanteListResponse>(
+    "/api/comprobantes-proveedor"
+  );
+  return data.items.map(mapListItemToComprobante);
+}
 
-  if (!res.ok) throw new Error("No se pudo listar comprobantes");
+type ProveedoresApiResponse = {
+  ok?: boolean;
+  data?: Array<{
+    id: number | string;
+    nombreCompleto?: string | null;
+    nombreFantasia?: string | null;
+    razonSocial?: string | null;
+    codigo?: string | null;
+  }>;
+};
 
-  const result = await res.json();
-  return result.items; // la API debe devolver { items, meta }
+export async function listProveedoresAction(): Promise<Supplier[]> {
+  const json = await fetchJson<ProveedoresApiResponse>(
+    "/api/proveedores?status=active&limit=100"
+  );
+
+  const entries = Array.isArray(json.data) ? json.data : [];
+  const unique = new Map<string, Supplier>();
+
+  for (const prov of entries) {
+    const id = String(prov.id);
+    const name =
+      prov.nombreFantasia?.trim() ||
+      prov.razonSocial?.trim() ||
+      prov.nombreCompleto?.trim() ||
+      prov.codigo?.trim() ||
+      `Proveedor ${id}`;
+
+    if (!unique.has(id)) {
+      unique.set(id, { id, name });
+    }
+  }
+
+  return Array.from(unique.values());
+}
+
+type DepositoApiResponse = {
+  ok?: boolean;
+  data?: Array<{ id: number | string; nombre?: string | null }>;
+};
+
+export async function listDepositosAction(): Promise<Deposito[]> {
+  const json = await fetchJson<DepositoApiResponse>("/api/deposito?estado=Activo");
+  const rows = Array.isArray(json.data) ? json.data : [];
+  const map = new Map<string, Deposito>();
+
+  for (const dep of rows) {
+    const id = String(dep.id);
+    const name = dep.nombre?.trim() || `Depósito ${id}`;
+    if (!map.has(id)) {
+      map.set(id, { id, name });
+    }
+  }
+
+  return Array.from(map.values());
+}
+
+type TipoMovimientoApiResponse = {
+  ok?: boolean;
+  data?: Array<{ id: number | string; nombre: string; saldo: boolean }>;
+};
+
+export async function listTiposMovimientoAction(): Promise<TipoMovimiento[]> {
+  const json = await fetchJson<TipoMovimientoApiResponse>("/api/tipos-movimientos");
+  const rows = Array.isArray(json.data) ? json.data : [];
+  return rows.map((tm) => ({ id: String(tm.id), name: tm.nombre, saldo: Boolean(tm.saldo) }));
+}
+
+export type OrdenCompraApiItem = {
+  id: number | string;
+  proveedorId?: number | string | null;
+  proveedor?: string | null;
+  depositoId?: number | string | null;
+  estado?: boolean | null;
+  total?: number | null;
+};
+
+type OrdenCompraApiResponse = {
+  data?: OrdenCompraApiItem[];
+};
+
+export async function listOrdenesCompraAction(): Promise<OrdenCompraApiItem[]> {
+  const json = await fetchJson<OrdenCompraApiResponse>(
+    "/api/ordenes-compra?estado=true&limit=100"
+  );
+  return Array.isArray(json.data) ? json.data : [];
 }
 
 // ===== Crear comprobante =====
@@ -32,13 +196,16 @@ export async function createComprobanteAction(payload: {
   items: DetalleComprobanteProveedor[];
   observaciones?: string;
 }): Promise<ComprobanteProveedor> {
-  const res = await fetch(`${baseUrl}/api/comprobantes-proveedor`, {
+  const res = await fetch(buildUrl("/api/comprobantes-proveedor"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
 
-  if (!res.ok) throw new Error("No se pudo crear el comprobante");
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`No se pudo crear el comprobante: ${text}`);
+  }
 
   const newComprobante = await res.json();
   revalidatePath("/comprobante-proveedor"); // refresca server component

--- a/src/app/comprobante-proveedor/page.tsx
+++ b/src/app/comprobante-proveedor/page.tsx
@@ -1,5 +1,12 @@
 import ComprasClient from "./comprobanteClient";
-import { listComprobanteAction } from "./actions/comprobante";
+import {
+  listComprobanteAction,
+  listProveedoresAction,
+  listDepositosAction,
+  listTiposMovimientoAction,
+  listOrdenesCompraAction,
+  type OrdenCompraApiItem,
+} from "./actions/comprobante";
 import type {
   ComprobanteProveedor,
   Supplier,
@@ -11,26 +18,121 @@ import type {
   PurchaseOrder,
 } from "@/lib/comprobante-proveedor/comprobante";
 
-// Si más adelante querés reemplazar los datos auxiliares por tablas reales:
-import { productsMock, purchaseOrdersMock } from "@/mocks/comprobante.mock";
+function dedupeById<T extends { id: string }>(items: T[]): T[] {
+  const map = new Map<string, T>();
+  for (const item of items) {
+    const key = String(item.id);
+    if (!map.has(key)) map.set(key, item);
+  }
+  return Array.from(map.values());
+}
+
+function mapOrdenesCompra(
+  raw: OrdenCompraApiItem[],
+  proveedores: Supplier[],
+  depositos: Deposito[],
+): PurchaseOrder[] {
+  const proveedorMap = new Map(proveedores.map((p) => [String(p.id), p]));
+  const depositoMap = new Map(depositos.map((d) => [String(d.id), d]));
+
+  return raw.map((oc) => {
+    const proveedorId = oc.proveedorId != null ? String(oc.proveedorId) : "";
+    const depositoId = oc.depositoId != null ? String(oc.depositoId) : "";
+
+    const supplier = proveedorMap.get(proveedorId) ?? {
+      id: proveedorId,
+      name: oc.proveedor ?? (proveedorId ? `Proveedor ${proveedorId}` : "Proveedor"),
+    };
+
+    const deposito = depositoMap.get(depositoId) ?? {
+      id: depositoId,
+      name: depositoId ? `Depósito ${depositoId}` : "Sin depósito",
+    };
+
+    return {
+      id: String(oc.id),
+      supplier,
+      deposito,
+      status: Boolean(oc.estado),
+      items: [],
+    } satisfies PurchaseOrder;
+  });
+}
 
 export default async function Page() {
-  let initialComprobantes: ComprobanteProveedor[] = [];
+  const [
+    comprobantesResult,
+    proveedoresResult,
+    depositosResult,
+    tiposMovimientoResult,
+    ordenesCompraResult,
+  ] = await Promise.allSettled([
+    listComprobanteAction(),
+    listProveedoresAction(),
+    listDepositosAction(),
+    listTiposMovimientoAction(),
+    listOrdenesCompraAction(),
+  ]);
 
-  try {
-    initialComprobantes = await listComprobanteAction();
-  } catch (err) {
-    console.error("Error listando comprobantes:", err);
+  const initialComprobantes: ComprobanteProveedor[] =
+    comprobantesResult.status === "fulfilled" ? comprobantesResult.value : [];
+
+  if (comprobantesResult.status === "rejected") {
+    console.error("Error listando comprobantes:", comprobantesResult.reason);
   }
 
-  // Datos auxiliares (estos sí podés reemplazarlos por la BDD real si las tenés)
-  const proveedores: Supplier[] = initialComprobantes.map(c => c.proveedor);
-  const depositos: Deposito[] = initialComprobantes.map(c => c.deposito);
-  const productos: Product[] = productsMock; // o fetch real
-  const tipoComprobantes: TipoComprobante[] = initialComprobantes.map(c => c.tipoComprobante);
-  const metodosPagos: MetodoPago[] = initialComprobantes.map(c => c.metodoPagoId).filter(Boolean) as MetodoPago[];
-  const tiposMovimiento: TipoMovimiento[] = initialComprobantes.map(c => c.tipoMovimiento);
-  const ordenCompra: PurchaseOrder[] = initialComprobantes.map(c => c.ordenCompra);
+  const proveedoresApi =
+    proveedoresResult.status === "fulfilled" ? proveedoresResult.value : [];
+  if (proveedoresResult.status === "rejected") {
+    console.error("Error listando proveedores:", proveedoresResult.reason);
+  }
+
+  const depositosApi =
+    depositosResult.status === "fulfilled" ? depositosResult.value : [];
+  if (depositosResult.status === "rejected") {
+    console.error("Error listando depósitos:", depositosResult.reason);
+  }
+
+  const tiposMovimientoApi =
+    tiposMovimientoResult.status === "fulfilled" ? tiposMovimientoResult.value : [];
+  if (tiposMovimientoResult.status === "rejected") {
+    console.error("Error listando tipos de movimiento:", tiposMovimientoResult.reason);
+  }
+
+  const ordenesCompraApi =
+    ordenesCompraResult.status === "fulfilled" ? ordenesCompraResult.value : [];
+  if (ordenesCompraResult.status === "rejected") {
+    console.error("Error listando órdenes de compra:", ordenesCompraResult.reason);
+  }
+
+  const proveedores = dedupeById([
+    ...initialComprobantes.map((c) => c.proveedor),
+    ...proveedoresApi,
+  ]);
+
+  const depositos = dedupeById([
+    ...initialComprobantes.map((c) => c.deposito),
+    ...depositosApi,
+  ]);
+
+  const tiposMovimiento = tiposMovimientoApi.length
+    ? tiposMovimientoApi
+    : dedupeById(initialComprobantes.map((c) => c.tipoMovimiento));
+
+  const ordenCompra = dedupeById([
+    ...initialComprobantes.map((c) => c.ordenCompra),
+    ...mapOrdenesCompra(ordenesCompraApi, proveedores, depositos),
+  ]);
+
+  const productos: Product[] = [];
+  const tipoComprobantes: TipoComprobante[] = dedupeById(
+    initialComprobantes.map((c) => c.tipoComprobante)
+  );
+  const metodosPagos: MetodoPago[] = dedupeById(
+    initialComprobantes
+      .map((c) => c.metodoPagoId)
+      .filter((m): m is MetodoPago => Boolean(m))
+  );
 
   return (
     <div className="p-2">


### PR DESCRIPTION
## Summary
- add shared helpers to call the comprobantes, proveedores, depósitos and tipos de movimiento APIs and map the responses to the UI types
- hydrate the comprobante de proveedor page with the API results, deduplicating data and falling back to existing records when necessary

## Testing
- npm run lint *(fails: eslint scans generated Prisma runtime with thousands of pre-existing violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d31bf2602483309dbb0be76e6da18c