### PR TITLE
Connect comprobante proveedor page to APIs

### DIFF
--- a/src/app/comprobante-proveedor/actions/comprobante.ts
+++ b/src/app/comprobante-proveedor/actions/comprobante.ts
@@ -2,45 +2,73 @@
 
 import { revalidatePath } from "next/cache";
 import type { ComprobanteProveedor, DetalleComprobanteProveedor } from "@/lib/comprobante-proveedor/comprobante";
-
-// Base URL de tu API (asegurate de definir NEXT_PUBLIC_BASE_URL en .env)
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL!;
+import { getBaseUrl } from "@/lib/http";
+import { normalizeComprobante } from "@/lib/comprobante-proveedor/normalizers";
 
 // ===== Listar comprobantes con relaciones =====
 export async function listComprobanteAction(): Promise<ComprobanteProveedor[]> {
-  const res = await fetch(`${baseUrl}/api/comprobantes-proveedor?include=proveedor,deposito,ordenCompra,tipoComprobante,metodoPago,tipoMovimiento,items`, {
+  const baseUrl = getBaseUrl();
+  const res = await fetch(`${baseUrl}/api/comprobantes-proveedor?limit=50`, {
     cache: "no-store",
   });
 
-  if (!res.ok) throw new Error("No se pudo listar comprobantes");
-
   const result = await res.json();
-  return result.items; // la API debe devolver { items, meta }
+  if (!res.ok) throw new Error(result?.error ?? "No se pudo listar comprobantes");
+
+  return Array.isArray(result?.items) ? result.items.map(normalizeComprobante) : [];
 }
 
 // ===== Crear comprobante =====
-export async function createComprobanteAction(payload: {
+type CreatePayload = {
+  ordenCompraId: string;
   proveedorId: string;
   depositoId?: string;
   fecha: string;
-  letra?: string;
-  numeroSucursal?: string;
-  numero?: string;
-  moneda?: string;
   tipoComprobanteId: string;
   metodoPagoId?: string;
+  tipoMovimientoId?: string;
+  letra?: string | null;
+  numeroSucursal?: string | null;
+  numero?: string | null;
+  moneda?: string | null;
+  observaciones?: string | null;
   items: DetalleComprobanteProveedor[];
-  observaciones?: string;
-}): Promise<ComprobanteProveedor> {
-  const res = await fetch(`${baseUrl}/api/comprobantes-proveedor`, {
+};
+
+export async function createComprobanteAction(payload: CreatePayload): Promise<void> {
+  const baseUrl = getBaseUrl();
+  const body = {
+    ordenCompraId: Number(payload.ordenCompraId),
+    proveedorId: Number(payload.proveedorId),
+    depositoId: payload.depositoId ? Number(payload.depositoId) : undefined,
+    tipoComprobanteId: Number(payload.tipoComprobanteId),
+    metodoPagoId: payload.metodoPagoId ? Number(payload.metodoPagoId) : undefined,
+    tipoMovimientoId: payload.tipoMovimientoId ? Number(payload.tipoMovimientoId) : undefined,
+    fecha: payload.fecha,
+    letra: payload.letra ?? null,
+    numeroSucursal: payload.numeroSucursal ?? null,
+    numero: payload.numero ?? null,
+    moneda: payload.moneda ?? null,
+    observaciones: payload.observaciones ?? null,
+    detalles: payload.items.map((item) => ({
+      productId: Number(item.productId),
+      quantity: Number(item.quantity),
+      unitPrice: Number(item.unitPrice),
+      discount: item.discount ?? 0,
+      observations: item.observations ?? "",
+    })),
+  };
+
+  const res = await fetch(`${baseUrl}/api/comprobantes-proveedor/nuevo`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(body),
   });
 
-  if (!res.ok) throw new Error("No se pudo crear el comprobante");
+  const json = await res.json();
+  if (!res.ok || !json?.ok) {
+    throw new Error(json?.error ?? "No se pudo crear el comprobante");
+  }
 
-  const newComprobante = await res.json();
-  revalidatePath("/comprobante-proveedor"); // refresca server component
-  return newComprobante;
+  revalidatePath("/comprobante-proveedor");
 }

--- a/src/app/comprobante-proveedor/comprobanteClient.tsx
+++ b/src/app/comprobante-proveedor/comprobanteClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import ComprasFilters from "@/components/comprobante-proveedor/ComprobanteFilters";
 import ComprasTable from "@/components/comprobante-proveedor/ComprobanteTable";
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/Button";
 import { Plus } from "lucide-react";
 
 import { applyFilters, applySort } from "@/lib/comprobante-proveedor/utils";
+import { normalizeComprobante } from "@/lib/comprobante-proveedor/normalizers";
 import type {
   ComprobanteProveedor,
   DetalleComprobanteProveedor,
@@ -43,6 +44,22 @@ type Props = {
   ordenCompra: PurchaseOrder[];
 };
 
+type ModalSubmitPayload = {
+  proveedorId: string;
+  depositoId: string;
+  fecha: string;
+  items: DetalleComprobanteProveedor[];
+  tipoMovimientoId: string;
+  tipoComprobanteId: string;
+  metodoPagoId: string;
+  ordenCompraId: string;
+  letra?: string | null;
+  numeroSucursal?: string | null;
+  numero?: string | null;
+  moneda?: string | null;
+  observaciones?: string | null;
+};
+
 export default function ComprobanteClient({
   initialComprobantes,
   proveedores,
@@ -65,6 +82,19 @@ export default function ComprobanteClient({
   const filtered = useMemo(() => applyFilters(comprobantes, filters), [comprobantes, filters]);
   const sorted = useMemo(() => applySort(filtered, sort), [filtered, sort]);
   const { page, pageItems, totalPages, next, prev, setPage, reset } = usePagination(sorted, 10);
+
+  const reloadComprobantes = useCallback(async () => {
+    try {
+      const res = await fetch("/api/comprobantes-proveedor?limit=50", { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? "No se pudo obtener comprobantes");
+      const rows = Array.isArray(json?.items) ? json.items.map(normalizeComprobante) : [];
+      setComprobantes(rows);
+      setPage(1);
+    } catch (err) {
+      console.error("Error recargando comprobantes", err);
+    }
+  }, [setPage]);
 
   // ===================== STATS =====================
   const montoTotal = useMemo(() => filtered.reduce((s, c) => s + c.total, 0), [filtered]);
@@ -97,44 +127,32 @@ export default function ComprobanteClient({
   }
 
   // ===================== CREAR / ACTUALIZAR =====================
-  async function handleSubmit(payload: {
-    proveedorId: string;
-    depositoId: string;
-    fecha: string;
-    items: DetalleComprobanteProveedor[];
-    totalCantidad: number;
-    totalMonto: number;
-    tipoMovimientoId: string;
-    tipoComprobanteId: string;
-    metodoPagoId: string;
-    ordenCompraId: string;
-    letra?: string | null;
-    numeroSucursal?: string | null;
-    numero?: string;
-    moneda?: string | null;
-    observaciones?: string | null;
-  }) {
-    setEditingId(null);
-    closeModal();
-
+  async function handleSubmit(payload: ModalSubmitPayload) {
     try {
-    // Convertir nulls a undefined
-    const cleanPayload = {
-      ...payload,
-      letra: payload.letra ?? undefined,
-      numeroSucursal: payload.numeroSucursal ?? undefined,
-      moneda: payload.moneda ?? undefined,
-      observaciones: payload.observaciones ?? undefined,
-    };
+      const body = {
+        ordenCompraId: payload.ordenCompraId,
+        proveedorId: payload.proveedorId,
+        depositoId: payload.depositoId,
+        fecha: payload.fecha,
+        tipoComprobanteId: payload.tipoComprobanteId,
+        metodoPagoId: payload.metodoPagoId,
+        tipoMovimientoId: payload.tipoMovimientoId,
+        letra: payload.letra ?? null,
+        numeroSucursal: payload.numeroSucursal ?? null,
+        numero: payload.numero ?? null,
+        moneda: payload.moneda ?? null,
+        observaciones: payload.observaciones ?? null,
+        items: payload.items,
+      };
 
-    const newComprobante = await createComprobanteAction(cleanPayload);
-
-    setComprobantes((prev) => [newComprobante, ...prev]);
-    setPage(1);
-  } catch (err) {
-    console.error(err);
-    alert("Error al crear el comprobante");
-  }
+      await createComprobanteAction(body);
+      await reloadComprobantes();
+      setEditingId(null);
+      closeModal();
+    } catch (err) {
+      console.error("Error al crear comprobante", err);
+      throw err;
+    }
   }
 
   // ===================== OPCIONES PARA MODAL Y FILTROS =====================
@@ -215,15 +233,16 @@ export default function ComprobanteClient({
         initial={
           editingId
             ? (() => {
-                const c = comprobantes.find((x) => x.id === editingId)!;
+                const c = comprobantes.find((x) => String(x.id) === String(editingId));
+                if (!c) return undefined;
                 return {
-                  proveedorId: c.proveedor.id,
-                  depositoId: c.deposito.id,
-                  fecha: c.fecha.split("T")[0],
-                  numero: c.numero,
-                  tipoComprobanteId: c.tipoComprobante.id,
-                  metodoPagoId: c.metodoPagoId?.id ?? "",
-                  items: c.items,
+                  proveedorId: c.proveedor?.id ?? "",
+                  depositoId: c.deposito?.id ?? "",
+                  fecha: c.fecha ? new Date(c.fecha).toISOString().split("T")[0] : "",
+                  numero: c.numero ?? c.nroComprobante ?? "",
+                  tipoComprobanteId: c.tipoComprobante?.id ?? "",
+                  metodoPagoId: c.metodoPago?.id ?? "",
+                  items: c.items ?? [],
                 };
               })()
             : undefined

--- a/src/app/comprobante-proveedor/page.tsx
+++ b/src/app/comprobante-proveedor/page.tsx
@@ -10,12 +10,17 @@ import type {
   TipoMovimiento,
   PurchaseOrder,
 } from "@/lib/comprobante-proveedor/comprobante";
-
-// Si más adelante querés reemplazar los datos auxiliares por tablas reales:
-import { productsMock, purchaseOrdersMock } from "@/mocks/comprobante.mock";
+import { getBaseUrl } from "@/lib/http";
+import {
+  normalizeDeposito,
+  normalizePurchaseOrder,
+  normalizeSupplier,
+  normalizeTipoMovimiento,
+} from "@/lib/comprobante-proveedor/normalizers";
 
 export default async function Page() {
   let initialComprobantes: ComprobanteProveedor[] = [];
+  const baseUrl = getBaseUrl();
 
   try {
     initialComprobantes = await listComprobanteAction();
@@ -23,14 +28,86 @@ export default async function Page() {
     console.error("Error listando comprobantes:", err);
   }
 
-  // Datos auxiliares (estos sí podés reemplazarlos por la BDD real si las tenés)
-  const proveedores: Supplier[] = initialComprobantes.map(c => c.proveedor);
-  const depositos: Deposito[] = initialComprobantes.map(c => c.deposito);
-  const productos: Product[] = productsMock; // o fetch real
-  const tipoComprobantes: TipoComprobante[] = initialComprobantes.map(c => c.tipoComprobante);
-  const metodosPagos: MetodoPago[] = initialComprobantes.map(c => c.metodoPagoId).filter(Boolean) as MetodoPago[];
-  const tiposMovimiento: TipoMovimiento[] = initialComprobantes.map(c => c.tipoMovimiento);
-  const ordenCompra: PurchaseOrder[] = initialComprobantes.map(c => c.ordenCompra);
+  async function safeFetch(path: string) {
+    try {
+      const res = await fetch(`${baseUrl}${path}`, { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json?.error ?? `Error al obtener ${path}`);
+      return json;
+    } catch (err) {
+      console.error(`Error consultando ${path}`, err);
+      return null;
+    }
+  }
+
+  const [proveedoresRes, depositosRes, ordenesRes, tiposMovimientoRes] = await Promise.all([
+    safeFetch("/api/proveedores?status=all"),
+    safeFetch("/api/deposito?estado=Activo"),
+    safeFetch("/api/ordenes-compra?limit=50"),
+    safeFetch("/api/tipos-movimientos"),
+  ]);
+
+  const proveedoresMap = new Map<string, Supplier>();
+  if (Array.isArray(proveedoresRes?.data)) {
+    for (const row of proveedoresRes.data) {
+      const supplier = normalizeSupplier(row);
+      if (supplier.id) proveedoresMap.set(supplier.id, supplier);
+    }
+  }
+  for (const c of initialComprobantes) {
+    if (c.proveedor?.id) proveedoresMap.set(c.proveedor.id, c.proveedor);
+  }
+  const proveedores = Array.from(proveedoresMap.values());
+
+  const depositosMap = new Map<string, Deposito>();
+  if (Array.isArray(depositosRes?.data)) {
+    for (const row of depositosRes.data) {
+      const dep = normalizeDeposito(row);
+      if (dep.id) depositosMap.set(dep.id, dep);
+    }
+  }
+  for (const c of initialComprobantes) {
+    if (c.deposito?.id) depositosMap.set(c.deposito.id, c.deposito);
+  }
+  const depositos = Array.from(depositosMap.values());
+
+  const ordenCompraMap = new Map<string, PurchaseOrder>();
+  if (Array.isArray(ordenesRes?.data)) {
+    for (const row of ordenesRes.data) {
+      const oc = normalizePurchaseOrder(row);
+      if (oc.id) ordenCompraMap.set(oc.id, oc);
+    }
+  }
+  for (const c of initialComprobantes) {
+    if (c.ordenCompra?.id) ordenCompraMap.set(c.ordenCompra.id, c.ordenCompra);
+  }
+  const ordenCompra = Array.from(ordenCompraMap.values());
+
+  const tiposMovimientoSet = new Map<string, TipoMovimiento>();
+  if (Array.isArray(tiposMovimientoRes?.data)) {
+    for (const row of tiposMovimientoRes.data) {
+      const tm = normalizeTipoMovimiento(row);
+      if (tm.id) tiposMovimientoSet.set(tm.id, tm);
+    }
+  }
+  for (const c of initialComprobantes) {
+    if (c.tipoMovimiento?.id) tiposMovimientoSet.set(c.tipoMovimiento.id, c.tipoMovimiento);
+  }
+  const tiposMovimiento = Array.from(tiposMovimientoSet.values());
+
+  const tiposComprobanteMap = new Map<string, TipoComprobante>();
+  for (const c of initialComprobantes) {
+    if (c.tipoComprobante?.id) tiposComprobanteMap.set(c.tipoComprobante.id, c.tipoComprobante);
+  }
+  const tipoComprobantes = Array.from(tiposComprobanteMap.values());
+
+  const metodosPagoMap = new Map<string, MetodoPago>();
+  for (const c of initialComprobantes) {
+    if (c.metodoPago?.id) metodosPagoMap.set(c.metodoPago.id, c.metodoPago);
+  }
+  const metodosPagos = Array.from(metodosPagoMap.values());
+
+  const productos: Product[] = [];
 
   return (
     <div className="p-2">

--- a/src/components/comprobante-proveedor/ComprobanteModal.tsx
+++ b/src/components/comprobante-proveedor/ComprobanteModal.tsx
@@ -51,8 +51,6 @@ type Props = {
     depositoId: string;
     fecha: string;
     items: DetalleComprobanteProveedor[];
-    totalCantidad: number;
-    totalMonto: number;
     tipoMovimientoId: string;
     tipoComprobanteId: string;
     metodoPagoId: string;
@@ -62,7 +60,7 @@ type Props = {
     numero?: string;
     moneda?: string | null;
     observaciones?: string | null;
-  }) => void;
+  }) => Promise<void> | void;
 };
 
 function money(n: number) {
@@ -106,6 +104,7 @@ export default function ComprasModal({
 
   const totalCantidad = useMemo(() => items.reduce((s, i) => s + (i.quantity ?? 0), 0), [items]);
   const totalMonto = useMemo(() => items.reduce((s, i) => s + (i.totalPrice ?? 0), 0), [items]);
+  const [submitting, setSubmitting] = useState(false);
 
   // Helper: normaliza id a string
     // helpers al inicio del componente (fuera del return)
@@ -282,49 +281,34 @@ const uniqueOrdenes = useMemo(() => {
   }
 
 
-  async function createComprobante() {
+  async function handleSubmit() {
     if (!proveedorId || !depositoId || !fecha || !tipoComprobanteId || !metodoPagoId || !ordenCompraId || items.length === 0) {
       alert("Completar todos los campos obligatorios y agregar al menos un producto");
       return;
     }
 
-    const body = {
-      ordenCompraId: Number(ordenCompraId),
-      tipoComprobanteId: Number(tipoComprobanteId),
-      fecha,
-      hora: undefined,
-      letra: letra || null,
-      numeroSucursal: numeroSucursal || null,
-      numero: numero || null,
-      tipoMovimientoId: Number(tipoMovimientoId),
-      moneda: moneda || null,
-      observaciones: observaciones || null,
-      detalles: items.map(i => ({
-        // ajusta al schema que espera tu backend; aquí usamos productId/quantity/unitPrice
-        productId: Number(i.productId),
-        quantity: Number(i.quantity),
-        unitPrice: Number(i.unitPrice),
-        discount: i.discount ?? 0,
-        observations: i.observations ?? "",
-      }))
-    };
-
     try {
-      const res = await fetch("/api/comprobantes-proveedor/nuevo", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
+      setSubmitting(true);
+      await onSubmit({
+        proveedorId,
+        depositoId,
+        fecha,
+        items,
+        tipoMovimientoId,
+        tipoComprobanteId,
+        metodoPagoId,
+        ordenCompraId,
+        letra: letra || null,
+        numeroSucursal: numeroSucursal || null,
+        numero: numero || null,
+        moneda: moneda || null,
+        observaciones: observaciones || null,
       });
-      const json = await res.json();
-      if (json.ok) {
-        alert("Comprobante creado correctamente");
-        onOpenChange(false);
-      } else {
-        alert("Error: " + (json.error ?? "Desconocido"));
-      }
     } catch (err) {
-      console.error(err);
-      alert("Error al conectar con el servidor");
+      console.error("Error al registrar comprobante", err);
+      alert("Error al registrar el comprobante");
+    } finally {
+      setSubmitting(false);
     }
   }
   
@@ -438,7 +422,14 @@ const uniqueOrdenes = useMemo(() => {
 
           <div className="flex justify-end gap-4 pt-2">
             <Button variant="outline" onClick={() => onOpenChange(false)}>Cancelar</Button>
-            <Button variant="primary" className="btn-primary" disabled={!proveedorId || !depositoId || !fecha || items.length === 0} onClick={createComprobante}>Registrar Comprobante de Proveedor</Button>
+            <Button
+              variant="primary"
+              className="btn-primary"
+              disabled={submitting || !proveedorId || !depositoId || !fecha || items.length === 0}
+              onClick={handleSubmit}
+            >
+              {submitting ? "Guardando..." : "Registrar Comprobante de Proveedor"}
+            </Button>
           </div>
         </div>
       </AlertDialogContent>

--- a/src/components/comprobante-proveedor/ComprobanteTable.tsx
+++ b/src/components/comprobante-proveedor/ComprobanteTable.tsx
@@ -43,6 +43,13 @@ function money(n: number) {
   return (n ?? 0).toLocaleString(undefined, { minimumFractionDigits: 0 });
 }
 
+function formatFecha(fecha?: string | null) {
+  if (!fecha) return "—";
+  const date = new Date(fecha);
+  if (Number.isNaN(date.getTime())) return String(fecha);
+  return date.toLocaleDateString();
+}
+
 export default function ComprasTable({
   comprobantes,
   onView,
@@ -103,27 +110,29 @@ export default function ComprasTable({
           <tbody>
             {comprobantes.map((comprobante, idx) => (
               <tr key={comprobante.id} className={idx % 2 === 0 ? "bg-white" : "bg-gray-50"}>
-                <td className="px-6 py-4 font-semibold text-blue-800">{comprobante.id}</td>
+                <td className="px-6 py-4 font-semibold text-blue-800">
+                  {comprobante.nroComprobante ?? comprobante.numero ?? comprobante.id}
+                </td>
 
                 <td className="px-6 py-4 text-gray-700">
                   <div>
-                    <div className="font-medium">{comprobante.fecha}</div>
+                    <div className="font-medium">{formatFecha(comprobante.fecha)}</div>
                   </div>
                 </td>
 
                 <td className="px-6 py-4">
                   <div className="font-medium text-gray-900 truncate max-w-[18ch]">
-                    {comprobante.ordenCompra.id}
+                    {comprobante.ordenCompra?.id ?? "—"}
                   </div>
                 </td>
 
                 <td className="px-6 py-4">
                   <div className="font-medium text-gray-900 truncate max-w-[18ch]">
-                    {comprobante.proveedor.name}
+                    {comprobante.proveedor?.name ?? "—"}
                   </div>
                 </td>
 
-                <td className="px-6 py-4 text-gray-700">{comprobante.deposito.name}</td>
+                <td className="px-6 py-4 text-gray-700">{comprobante.deposito?.name ?? "—"}</td>
 
                 <td className="px-6 py-4 font-semibold text-gray-900">
                   ${money(comprobante.total)}
@@ -138,7 +147,7 @@ export default function ComprasTable({
                     <Button
                       size="sm"
                       variant="ghost"
-                      onClick={() => onView?.(comprobante.id)}
+                      onClick={() => onView?.(String(comprobante.id))}
                       title="Ver"
                       aria-label={`Ver ${comprobante.id}`}
                     >
@@ -149,7 +158,7 @@ export default function ComprasTable({
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => onEdit(comprobante.id)}
+                        onClick={() => onEdit(String(comprobante.id))}
                         title="Editar"
                         aria-label={`Editar ${comprobante.id}`}
                       >

--- a/src/lib/comprobante-proveedor/comprobante.ts
+++ b/src/lib/comprobante-proveedor/comprobante.ts
@@ -9,8 +9,8 @@ export type Supplier = {
 export type Product = {
   id: string;
   name: string;
-  code: string;
-  price: number;
+  code?: string;
+  price?: number;
 };
 
 export type Deposito = {
@@ -22,17 +22,17 @@ export type PurchaseOrderItem = {
   id: string;
   productId: string;
   productName: string;
-  cantidad: number;
-  precioUnitario: number;
-  total: number;
+  cantidad?: number;
+  precioUnitario?: number;
+  total?: number;
 };
 
 export type PurchaseOrder = {
   id: string;
-  supplier: { id: string; name: string;};
-  deposito: { id: string; name: string;};
-  status: boolean;
-  items: PurchaseOrderItem[];
+  supplier?: { id: string; name: string } | null;
+  deposito?: { id: string; name: string } | null;
+  status?: boolean | null;
+  items?: PurchaseOrderItem[];
 };
 
 export type TipoMovimiento = {
@@ -64,31 +64,32 @@ export type DetalleComprobanteProveedor = {
 
 export type ComprobanteProveedor = {
   id: string;
-  ordenCompra : PurchaseOrder;
-  proveedor:  { id: string; name: string};
-  deposito: { id: string; name: string};
+  nroComprobante?: string | null;
+  ordenCompra?: PurchaseOrder | null;
+  proveedor: Supplier;
+  deposito?: Deposito | null;
 
   letra?: string | null;
   numeroSucursal?: string | null;
-  numero: string;
+  numero?: string | null;
   moneda?: string | null;
 
-  tipoComprobante: TipoComprobante;
+  tipoComprobante?: TipoComprobante | null;
 
-  fecha: string; // ISO string
+  fecha?: string | null; // ISO string
   hora?: string | null;
 
   total: number;
   saldo: number;
 
-  metodoPagoId?: MetodoPago;
+  metodoPago?: MetodoPago | null;
 
-  estado: boolean;
+  estado?: boolean | null;
   observaciones?: string | null;
 
-  tipoMovimiento: TipoMovimiento;
+  tipoMovimiento?: TipoMovimiento | null;
 
-  items: DetalleComprobanteProveedor[];
+  items?: DetalleComprobanteProveedor[];
 };
 
 // Filtros

--- a/src/lib/comprobante-proveedor/normalizers.ts
+++ b/src/lib/comprobante-proveedor/normalizers.ts
@@ -1,0 +1,238 @@
+import type {
+  ComprobanteProveedor,
+  Deposito,
+  DetalleComprobanteProveedor,
+  MetodoPago,
+  PurchaseOrder,
+  Supplier,
+  TipoComprobante,
+  TipoMovimiento,
+} from "./comprobante";
+
+type UnknownRecord = Record<string, unknown>;
+
+function toRecord(value: unknown): UnknownRecord {
+  return value && typeof value === "object" ? (value as UnknownRecord) : {};
+}
+
+function pickRecord(value: unknown): UnknownRecord | null {
+  return value && typeof value === "object" ? (value as UnknownRecord) : null;
+}
+
+function toStringId(value: unknown, fallback = ""): string {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return fallback;
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function takeString(...candidates: Array<unknown>): string | undefined {
+  for (const candidate of candidates) {
+    const str = toStringId(candidate);
+    if (str) return str;
+  }
+  return undefined;
+}
+
+export function normalizeSupplier(raw: unknown): Supplier {
+  const input = toRecord(raw);
+  const id = toStringId(
+    input.id ?? input.proveedorId ?? input.supplierId ?? input.value ?? ""
+  );
+  const name =
+    takeString(
+      input.name,
+      input.nombre,
+      input.razonSocial,
+      input.razon_social,
+      input.nombreCompleto,
+      input.descripcion,
+    ) ?? (id ? `Proveedor ${id}` : "Proveedor");
+  return { id, name };
+}
+
+export function normalizeDeposito(raw: unknown): Deposito {
+  const input = toRecord(raw);
+  const id = toStringId(input.id ?? input.depositoId ?? "");
+  const name =
+    takeString(input.name, input.nombre, input.deposito) ??
+    (id ? `Depósito ${id}` : "Depósito");
+  return { id, name };
+}
+
+function normalizeDetalle(raw: unknown, index: number): DetalleComprobanteProveedor {
+  const det = toRecord(raw);
+  const productId = toStringId(det.productoId ?? det.productId ?? index, String(index));
+  const producto = pickRecord(det.producto);
+  const productName =
+    takeString(
+      producto?.nombre,
+      det.productoNombre,
+      det.productName,
+      det.producto,
+      det.nombre,
+    ) ?? `Producto ${productId || index + 1}`;
+
+  const quantity = toNumber(det.cantidad ?? det.quantity ?? 0, 0);
+  const unitPrice = toNumber(det.precioUnitario ?? det.unitPrice ?? 0, 0);
+  const totalPrice = toNumber(
+    det.totalPrice ?? det.precioXCantidad ?? quantity * unitPrice,
+    quantity * unitPrice,
+  );
+
+  return {
+    id: toStringId(det.id ?? `${productId}-${index}`),
+    productId,
+    productName,
+    quantity,
+    unitPrice,
+    totalPrice,
+    discount: det.descuento as number | undefined ?? (det.discount as number | undefined),
+    observations: (det.observaciones as string | undefined) ?? (det.observations as string | undefined),
+  };
+}
+
+export function normalizeTipoComprobante(raw: unknown): TipoComprobante {
+  const input = toRecord(raw);
+  return {
+    id: toStringId(input.id ?? input.tipoComprobanteId ?? input.value ?? ""),
+    name: takeString(input.name, input.nombre, input.descripcion) ?? "Tipo de comprobante",
+  };
+}
+
+export function normalizeMetodoPago(raw: unknown): MetodoPago {
+  const input = toRecord(raw);
+  return {
+    id: toStringId(input.id ?? input.metodoPagoId ?? input.value ?? ""),
+    name: takeString(input.name, input.nombre, input.descripcion) ?? "Método de pago",
+  };
+}
+
+export function normalizeTipoMovimiento(raw: unknown): TipoMovimiento {
+  const input = toRecord(raw);
+  return {
+    id: toStringId(input.id ?? input.tipoMovimientoId ?? ""),
+    name: takeString(input.name, input.nombre) ?? "Movimiento",
+    saldo: Boolean(
+      input.saldo ?? input.esIngreso ?? true,
+    ),
+  };
+}
+
+export function normalizePurchaseOrder(raw: unknown): PurchaseOrder {
+  const input = toRecord(raw);
+  const supplier = pickRecord(input.supplier)
+    ? normalizeSupplier(input.supplier)
+    : pickRecord(input.proveedor)
+    ? normalizeSupplier({ id: input.proveedorId, nombre: input.proveedor })
+    : input.proveedorId
+    ? normalizeSupplier({ id: input.proveedorId })
+    : undefined;
+
+  const deposito = pickRecord(input.deposito)
+    ? normalizeDeposito(input.deposito)
+    : input.depositoId
+    ? normalizeDeposito({ id: input.depositoId, nombre: input.depositoNombre })
+    : undefined;
+
+  const rawItems = Array.isArray(input.items) ? input.items : undefined;
+  const items = rawItems?.map((item, idx) => {
+    const itemRecord = toRecord(item);
+    const producto = pickRecord(itemRecord.producto);
+    return {
+      id: toStringId(itemRecord.id ?? `${input.id ?? "oc"}-${idx}`),
+      productId: toStringId(itemRecord.productoId ?? itemRecord.productId ?? idx, String(idx)),
+      productName:
+        takeString(
+          producto?.nombre,
+          itemRecord.productName,
+          itemRecord.productoNombre,
+          itemRecord.producto,
+        ) ?? `Producto ${idx + 1}`,
+      cantidad: toNumber(itemRecord.cantidad ?? itemRecord.quantity ?? 0, 0),
+      precioUnitario: toNumber(itemRecord.precioUnitario ?? itemRecord.unitPrice ?? 0, 0),
+      total: toNumber(itemRecord.total ?? itemRecord.precioXCantidad ?? 0, 0),
+    };
+  });
+
+  return {
+    id: toStringId(input.id ?? input.ordenCompraId ?? input.nro ?? input.nroOC ?? ""),
+    supplier,
+    deposito,
+    status: (input.estado as boolean | undefined) ?? (input.status as boolean | undefined) ?? null,
+    items,
+  };
+}
+
+export function normalizeComprobante(raw: unknown): ComprobanteProveedor {
+  const input = toRecord(raw);
+  const proveedor = normalizeSupplier(
+    pickRecord(input.proveedor) ?? { id: input.proveedorId, nombre: input.proveedorNombre }
+  );
+
+  const deposito = pickRecord(input.deposito)
+    ? normalizeDeposito(input.deposito)
+    : input.depositoId
+    ? normalizeDeposito({ id: input.depositoId, nombre: input.depositoNombre })
+    : null;
+
+  const tipoComprobante = pickRecord(input.tipoComprobante)
+    ? normalizeTipoComprobante(input.tipoComprobante)
+    : input.tipo_comprobante
+    ? normalizeTipoComprobante({ id: input.tipoComprobanteId, nombre: input.tipo_comprobante })
+    : null;
+
+  const metodoPago = pickRecord(input.metodoPago)
+    ? normalizeMetodoPago(input.metodoPago)
+    : null;
+
+  const tipoMovimiento = pickRecord(input.tipoMovimiento)
+    ? normalizeTipoMovimiento(input.tipoMovimiento)
+    : input.tipo_movimiento
+    ? normalizeTipoMovimiento({ id: input.tipoMovimientoId, nombre: input.tipo_movimiento })
+    : null;
+
+  const ordenCompra = pickRecord(input.ordenCompra)
+    ? normalizePurchaseOrder(input.ordenCompra)
+    : null;
+
+  const detalles = Array.isArray(input.items)
+    ? input.items
+    : Array.isArray(input.detalleComprobante)
+    ? input.detalleComprobante
+    : [];
+
+  return {
+    id: toStringId(input.id ?? ""),
+    nroComprobante: input.nro_comprobante
+      ? toStringId(input.nro_comprobante)
+      : toStringId(input.nroComprobante ?? "" ) || null,
+    ordenCompra,
+    proveedor,
+    deposito,
+    letra: (input.letra as string | null | undefined) ?? null,
+    numeroSucursal: (input.numeroSucursal as string | null | undefined) ?? null,
+    numero: input.numero ? toStringId(input.numero) : input.nro_comprobante ? toStringId(input.nro_comprobante) : null,
+    moneda: (input.moneda as string | null | undefined) ?? null,
+    tipoComprobante,
+    fecha: input.fecha ? new Date(String(input.fecha)).toISOString() : null,
+    hora: input.hora ? toStringId(input.hora) : null,
+    total: toNumber(input.total ?? 0, 0),
+    saldo: toNumber(input.saldo ?? input.pendiente ?? 0, 0),
+    metodoPago,
+    estado: (input.estado as boolean | null | undefined) ?? null,
+    observaciones: (input.observaciones as string | null | undefined) ?? null,
+    tipoMovimiento,
+    items: detalles.map((item, idx) => normalizeDetalle(item, idx)),
+  };
+}
+
+export function normalizeTipoMovimientoList(raw: unknown): TipoMovimiento[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((row) => normalizeTipoMovimiento(row));
+}

--- a/src/lib/comprobante-proveedor/utils.ts
+++ b/src/lib/comprobante-proveedor/utils.ts
@@ -5,22 +5,23 @@ export function money(n: number) {
   return (n ?? 0).toLocaleString(undefined, { minimumFractionDigits: 0 });
 }
 
-// Convierte "dd/mm/yyyy" a Date (para comparar)
-export function parseDDMMYYYY(dmy: string): Date | null {
-  const [d, m, y] = dmy.split("/").map(Number);
-  if (!d || !m || !y) return null;
-  return new Date(y, m - 1, d);
-}
-
 // Aplica filtros al arreglo de órdenes
 export function applyFilters(data: ComprobanteProveedor[], f: ComprobanteFiltersState): ComprobanteProveedor[] {
   let out = [...data];
   if (f.numeroCP) {
     const q = f.numeroCP.toLowerCase();
-    out = out.filter((o) => o.id.toLowerCase().includes(q));
+    out = out.filter((o) => {
+      const values = [o.nroComprobante, o.numero, o.id]
+        .map((v) => (v == null ? "" : String(v).toLowerCase()));
+      return values.some((v) => v.includes(q));
+    });
   }
-  if (f.proveedorId) out = out.filter((o) => o.proveedor.id === f.proveedorId);
-  if (f.depositoId) out = out.filter((o) => o.deposito.id === f.depositoId);
+  if (f.proveedorId) {
+    out = out.filter((o) => String(o.proveedor?.id ?? "") === String(f.proveedorId));
+  }
+  if (f.depositoId) {
+    out = out.filter((o) => String(o.deposito?.id ?? "") === String(f.depositoId));
+  }
 
 
   // Rango de fechas (creationDate dd/mm/yyyy vs filtros yyyy-mm-dd)
@@ -28,7 +29,8 @@ export function applyFilters(data: ComprobanteProveedor[], f: ComprobanteFilters
   const to = f.fechaHasta ? new Date(f.fechaHasta) : null;
   if (from || to) {
     out = out.filter((o) => {
-      const d = new Date(o.fecha);
+      const fecha = o.fecha ?? o.hora ?? null;
+      const d = fecha ? new Date(fecha) : null;
       if (!d) return true;
       if (from && d < from) return false;
       if (to) {
@@ -52,27 +54,25 @@ export function applySort(data: ComprobanteProveedor[], sort?: SortState): Compr
     let bv: string | number = "";
     switch (key) {
       case "id":
-        av = a.id; bv = b.id; break;
+        av = String(a.id ?? ""); bv = String(b.id ?? ""); break;
       case "fecha": {
-        const ad = parseDDMMYYYY(a.fecha)?.getTime() ?? 0;
-        const bd = parseDDMMYYYY(b.fecha)?.getTime() ?? 0;
+        const ad = a.fecha ? new Date(a.fecha).getTime() : 0;
+        const bd = b.fecha ? new Date(b.fecha).getTime() : 0;
         av = ad; bv = bd; break;
       }
       case "proveedor":
-        av = a.proveedor.name.toLowerCase(); bv = b.proveedor.name.toLowerCase(); break;
-      case "proveedor":
-        av = a.proveedor.name.toLowerCase();
-        bv = b.proveedor.name.toLowerCase();
+        av = (a.proveedor?.name ?? "").toLowerCase();
+        bv = (b.proveedor?.name ?? "").toLowerCase();
         break;
 
       case "deposito":
-        av = a.deposito.name.toLowerCase();
-        bv = b.deposito.name.toLowerCase();
+        av = (a.deposito?.name ?? "").toLowerCase();
+        bv = (b.deposito?.name ?? "").toLowerCase();
         break;
 
       case "numero":
-        av = a.numero;
-        bv = b.numero;
+        av = String(a.numero ?? "");
+        bv = String(b.numero ?? "");
         break;
 
       case "total":
@@ -91,17 +91,17 @@ export function applySort(data: ComprobanteProveedor[], sort?: SortState): Compr
         break;
 
       case "tipoComprobante":
-        av = a.tipoComprobante.name.toLowerCase();
-        bv = b.tipoComprobante.name.toLowerCase();
+        av = (a.tipoComprobante?.name ?? "").toLowerCase();
+        bv = (b.tipoComprobante?.name ?? "").toLowerCase();
         break;
 
       case "tipoMovimiento":
-        av = a.tipoMovimiento.name.toLowerCase();
-        bv = b.tipoMovimiento.name.toLowerCase();
+        av = (a.tipoMovimiento?.name ?? "").toLowerCase();
+        bv = (b.tipoMovimiento?.name ?? "").toLowerCase();
         break;
     }
     if (av < bv) return -1;
-    if (av > bv) return 1;  
+    if (av > bv) return 1;
     return 0;
   });
   return dir === "desc" ? s.reverse() : s;

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,15 @@
+export function getBaseUrl() {
+  if (process.env.NEXT_PUBLIC_BASE_URL && process.env.NEXT_PUBLIC_BASE_URL.trim()) {
+    return process.env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, "");
+  }
+
+  if (process.env.NEXT_BASE_URL && process.env.NEXT_BASE_URL.trim()) {
+    return process.env.NEXT_BASE_URL.replace(/\/$/, "");
+  }
+
+  if (process.env.VERCEL_URL && process.env.VERCEL_URL.trim()) {
+    return `https://${process.env.VERCEL_URL.replace(/\/$/, "")}`;
+  }
+
+  return "http://localhost:3000";
+}

--- a/src/mocks/comprobante.mock.ts
+++ b/src/mocks/comprobante.mock.ts
@@ -76,7 +76,7 @@ export const comprobanteProveedorMock: ComprobanteProveedor = {
   hora: "10:45",
   total: 40000,
   saldo: 40000,
-  metodoPagoId: metodoPagosMock[0],
+  metodoPago: metodoPagosMock[0],
   estado: true,
   observaciones: "Comprobante de prueba",
   tipoMovimiento: tipoMovimientosMock[0],


### PR DESCRIPTION
## Summary
- fetch proveedores, depósitos, órdenes y tipos de movimiento desde las APIs en el server component de comprobantes y combinarlos con los datos iniciales normalizados
- actualizar el cliente para reutilizar normalizadores, refrescar la tabla tras crear un comprobante y manejar el nuevo payload de creación con los helpers
- ajustar la modal, la tabla y los tipos utilitarios para la nueva forma de los datos, además de añadir utilidades para obtener el base URL y normalizar respuestas

## Testing
- npm run lint *(falla por múltiples issues previos en archivos generados)*
- npx eslint src/lib/comprobante-proveedor/normalizers.ts

------
https://chatgpt.com/codex/tasks/task_e_68d31bf2602483309dbb0be76e6da18c